### PR TITLE
Experiment with a trait for Hash functions

### DIFF
--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -116,6 +116,7 @@ pub fn sha384(data: &[u8], result: &mut [u8; SHA384_RESULT_SIZE]) {
 mod test {
     use super::*;
     use std::mem::size_of;
+    #[cfg(target_os = "windows")]
     use symcrypt_sys::{SymCryptSha256Algorithm, SymCryptSha384Algorithm};
 
     fn check_hash_size(hash: symcrypt_sys::PCSYMCRYPT_HASH) -> symcrypt_sys::SIZE_T {
@@ -170,6 +171,7 @@ mod test {
         assert_eq!(hex::encode(result), expected);
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn check_state_size() {
         unsafe {

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -6,6 +6,13 @@ use symcrypt_sys;
 pub const SHA256_RESULT_SIZE: usize = symcrypt_sys::SYMCRYPT_SHA256_RESULT_SIZE as usize;
 pub const SHA384_RESULT_SIZE: usize = symcrypt_sys::SYMCRYPT_SHA384_RESULT_SIZE as usize;
 
+pub trait Hash {
+    type Result;
+
+    fn append(&mut self, data: &[u8]);
+    fn result(&mut self, result: &mut Self::Result);
+}
+
 pub struct Sha256State {
     state: symcrypt_sys::SYMCRYPT_SHA256_STATE,
 }
@@ -20,8 +27,12 @@ impl Sha256State {
         }
         instance
     }
+}
 
-    pub fn append(&mut self, data: &[u8]) {
+impl Hash for Sha256State {
+    type Result = [u8; SHA256_RESULT_SIZE];
+
+    fn append(&mut self, data: &[u8]) {
         unsafe {
             symcrypt_sys::SymCryptSha256Append(
                 &mut self.state,                    // pState
@@ -31,7 +42,7 @@ impl Sha256State {
         }
     }
 
-    pub fn result(&mut self, result: &mut [u8; SHA256_RESULT_SIZE]) {
+    fn result(&mut self, result: &mut [u8; SHA256_RESULT_SIZE]) {
         unsafe {
             symcrypt_sys::SymCryptSha256Result(&mut self.state, result.as_mut_ptr());
         }
@@ -73,8 +84,12 @@ impl Sha384State {
         }
         instance
     }
+}
 
-    pub fn append(&mut self, data: &[u8]) {
+impl Hash for Sha384State {
+    type Result = [u8; SHA384_RESULT_SIZE];
+
+    fn append(&mut self, data: &[u8]) {
         unsafe {
             symcrypt_sys::SymCryptSha384Append(
                 &mut self.state,                    // pState
@@ -84,7 +99,7 @@ impl Sha384State {
         }
     }
 
-    pub fn result(&mut self, result: &mut [u8; SHA384_RESULT_SIZE]) {
+    fn result(&mut self, result: &mut [u8; SHA384_RESULT_SIZE]) {
         unsafe {
             symcrypt_sys::SymCryptSha384Result(&mut self.state, result.as_mut_ptr());
         }
@@ -127,6 +142,19 @@ mod test {
         result
     }
 
+    fn test_generic_hash_state<H: Hash>(
+        mut hash_state: H,
+        data: &[u8],
+        result_buf: &mut H::Result,
+        expected: &str,
+    ) where
+        H::Result: AsRef<[u8]>,
+    {
+        hash_state.append(data);
+        hash_state.result(result_buf);
+        assert_eq!(hex::encode(result_buf), expected);
+    }
+
     #[test]
     fn stateless_sha256_hash() {
         let data = hex::decode("641ec2cf711e").unwrap();
@@ -142,11 +170,12 @@ mod test {
         let data = hex::decode("").unwrap();
         let expected: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
-        let mut sha_test = Sha256State::new();
-        let mut result: [u8; SHA256_RESULT_SIZE] = [0; SHA256_RESULT_SIZE];
-        Sha256State::append(&mut sha_test, &data);
-        Sha256State::result(&mut sha_test, &mut result);
-        assert_eq!(hex::encode(result), expected);
+        test_generic_hash_state(
+            Sha256State::new(),
+            &data,
+            &mut [0; SHA256_RESULT_SIZE],
+            expected,
+        );
     }
 
     #[test]
@@ -164,11 +193,12 @@ mod test {
         let data = hex::decode("f268267bfb73d5417ac2bc4a5c64").unwrap();
         let expected: &str = "6f246b1f839e73e585c6356c01e9878ff09e9904244ed0914edb4dc7dbe9ceef3f4695988d521d14d30ee40b84a4c3c8";
 
-        let mut sha_test = Sha384State::new();
-        let mut result: [u8; SHA384_RESULT_SIZE] = [0; SHA384_RESULT_SIZE];
-        Sha384State::append(&mut sha_test, &data);
-        Sha384State::result(&mut sha_test, &mut result);
-        assert_eq!(hex::encode(result), expected);
+        test_generic_hash_state(
+            Sha384State::new(),
+            &data,
+            &mut [0; SHA384_RESULT_SIZE],
+            expected,
+        );
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
See #10.

This shows an example of what a `Hash` trait might look like. I also wrote a generic test function that shows how you can write code that is largely agnostic about what hash function it's using.

I think this can still be improved quite a bit, but I wanted to share the idea so far.

Feel free not to merge this, I'm mostly posting it as an example.